### PR TITLE
docs: Update CI badge to use shields.io and match style

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub download](https://img.shields.io/github/downloads/Addono/HathiTrust-downloader/total.svg?style=flat-square&logo=github)][github-releases]
 [![GitHub stars](https://img.shields.io/github/stars/Addono/HathiTrust-downloader?style=flat-square)](https://github.com/Addono/HathiTrust-downloader/stargazers)
 [![License](https://img.shields.io/github/license/Addono/HathiTrust-downloader.svg?style=flat-square)](LICENSE)
-[![CI](https://github.com/Addono/HathiTrust-downloader/actions/workflows/ci.yaml/badge.svg?event=push)][ci-badge]
+[![CI](https://img.shields.io/github/actions/workflow/status/Addono/HathiTrust-downloader/ci.yaml?event=push&style=flat-square)][ci-badge]
 
 ## Installing
 
@@ -81,7 +81,7 @@ Make sure that you can access books on HathiTrust. Try to open a book in your br
 
 [pypi]: https://pypi.org/project/hathitrust-downloader/
 [github-releases]: https://github.com/Addono/HathiTrust-downloader/releases/latest
-[ci-badge]: https://github.com/Addono/HathiTrust-downloader/actions/workflows/ci.yaml/badge.svg?event=push
+[ci-badge]: https://img.shields.io/github/actions/workflow/status/Addono/HathiTrust-downloader/ci.yaml?event=push&style=flat-square
 
 ## Developing
 


### PR DESCRIPTION
Update the CI badge in the `README.md` to use shields.io and match the style of the other badges.

* Change the CI badge URL to `https://img.shields.io/github/actions/workflow/status/Addono/HathiTrust-downloader/ci.yaml?event=push&style=flat-square`
* Update the `[ci-badge]` reference to the new URL

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Addono/HathiTrust-downloader/pull/19?shareId=745f6a3e-c7ce-4161-be83-47c5501048a1).