### PR TITLE
feat: Adds optional support for giving a complete URL as the ID field

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ usage: hathitrust-downloader [-h] [--name NAME] id start_page end_page
 Book downloader for HathiTrust
 
 positional arguments:
-  id           The ID of the book, e.g 'mdp.39015027794331'.
+  id           The ID of the book, e.g 'mdp.39015027794331' or a complete URL.
   start_page   The page number of the first page to be downloaded.
   end_page     The last number of the last page to be downloaded (inclusive).
 
@@ -71,6 +71,10 @@ hathitrust-downloader mdp.39015073487137 1 10 --name my-book
 > ```
 > https://babel.hathitrust.org/cgi/pt?id=mdp.39015073487137&seq=13
 >                                        ^^^^^^^^^^^^^^^^^^ This demarks the ID of this book
+> ```
+> Alternatively, you can provide the complete URL as the ID argument, and the tool will extract the ID for you:
+> ```
+> hathitrust-downloader "https://babel.hathitrust.org/cgi/pt?id=mdp.39015073487137&seq=1" 1 10 --name my-book
 > ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -72,10 +72,7 @@ hathitrust-downloader mdp.39015073487137 1 10 --name my-book
 > https://babel.hathitrust.org/cgi/pt?id=mdp.39015073487137&seq=13
 >                                        ^^^^^^^^^^^^^^^^^^ This demarks the ID of this book
 > ```
-> Alternatively, you can provide the complete URL as the ID argument, and the tool will extract the ID for you:
-> ```
-> hathitrust-downloader "https://babel.hathitrust.org/cgi/pt?id=mdp.39015073487137&seq=1" 1 10 --name my-book
-> ```
+> Alternatively, you can provide the complete URL as the ID argument, and the tool will attempt to parse the ID from the URL. Note that this feature is best-effort, and for optimal stability, it is still recommended to provide the specific ID directly.
 
 ## Troubleshooting
 

--- a/hathitrustdownloader/cli.py
+++ b/hathitrustdownloader/cli.py
@@ -3,16 +3,38 @@ import os
 import requests
 import time
 import argparse
+from urllib.parse import urlparse, parse_qs
+
+def extract_id_from_url(url):
+    """
+    Extracts the ID parameter from a given URL.
+
+    Args:
+        url (str): The URL containing the ID parameter.
+
+    Returns:
+        str: The value of the ID parameter if found, otherwise None.
+    """
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query)
+    return query_params.get('id', [None])[0]
 
 def main():
     parser = argparse.ArgumentParser(description='Book downloader for HathiTrust')
 
-    parser.add_argument('id', type=str, help="The ID of the book, e.g 'mdp.39015027794331'.")
+    parser.add_argument('id', type=str, help="The ID of the book, e.g 'mdp.39015027794331' or a complete URL.")
     parser.add_argument('start_page', type=int, help="The page number of the first page to be downloaded.")
     parser.add_argument('end_page', type=int, help="The last number of the last page to be downloaded (inclusive).")
     parser.add_argument('--name', dest='name', type=str, help="The start of the filename. Defaults to using the id. This can also be used to change the path.")
 
     args = parser.parse_args()
+
+    # If the id argument is a URL, extract the ID from it
+    if args.id.startswith('http'):
+        args.id = extract_id_from_url(args.id)
+        if not args.id:
+            print("Error: Could not extract ID from the provided URL.")
+            return
 
     # If --name is used to specify a path, extract the directory part
     if args.name:

--- a/tests/test_hathitrustdownloader.bats
+++ b/tests/test_hathitrustdownloader.bats
@@ -35,3 +35,9 @@ teardown() {
   [ -f "$TMP_DIR/test_multiple_pages_p000001.pdf" ]
   [ -f "$TMP_DIR/test_multiple_pages_p000002.pdf" ]
 }
+
+@test "Download using a complete URL" {
+  run hathitrust-downloader "https://babel.hathitrust.org/cgi/pt?id=mdp.39015027794331&seq=1" 1 1 --name "$TMP_DIR/test_url_page"
+  [ "$status" -eq 0 ]
+  [ -f "$TMP_DIR/test_url_page_p000000.pdf" ]
+}


### PR DESCRIPTION
Add support for parsing the value of the ID parameter from URLs.

* Add `extract_id_from_url` function in `hathitrustdownloader/cli.py` to extract the ID parameter from a given URL.
* Modify the `main` function in `hathitrustdownloader/cli.py` to use the new function to extract the ID if the provided argument is a URL.
* Update the help text in `hathitrustdownloader/cli.py` to describe the new feature.
* Add a test case in `tests/test_hathitrustdownloader.bats` to verify that the ID is correctly parsed from a complete URL.
* Update `README.md` to describe the new feature and provide an example of using a complete URL as the ID argument.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Addono/HathiTrust-downloader/pull/22?shareId=2757356c-4be0-45e6-8c49-203b2a98e319).