### PR TITLE
Add cookies authentication CLI option and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Now you can use the tool by typing commands into the shell like this, and then p
 The help should give some instructions on how to use the tool:
 
 usage: hathitrust-downloader [-h] [--name NAME] [--user-agent USER_AGENT]
-                             [--max-retries MAX_RETRIES] [--cert CERT_FILE]
-                             [--key KEY_FILE]
+                             [--max-retries MAX_RETRIES] [--cookies COOKIE_JAR]
+                             [--cert CERT_FILE] [--key KEY_FILE]
                              id start_page end_page
 
 Book downloader for HathiTrust
@@ -71,6 +71,7 @@ options:
                         The User-Agent string to use for requests.
   --max-retries MAX_RETRIES
                         The maximum number of retries for retriable errors (e.g., 403 Forbidden) before skipping a page. Default is 8.
+  --cookies COOKIE_JAR  Path to a Netscape-format cookie jar file for authenticated requests.
   --cert CERT_FILE      Path to a client SSL certificate file (PEM format) for authentication.
   --key KEY_FILE        Path to a private key file (PEM format) corresponding to the client certificate.
 ```
@@ -98,6 +99,43 @@ hathitrust-downloader mdp.39015073487137 1 10 --name my-book
 > hathitrust-downloader 'https://babel.hathitrust.org/cgi/pt?id=mdp.39015073487137&seq=13' 1 10 --name my-book
 > ```
 
+### Authentication
+
+Some books on HathiTrust are only available if you are logged in through a partner institution, or if you are connecting from a specific region (e.g. the United States). If you are getting **403 Forbidden** errors or the download keeps retrying without making progress, you may need to pass your browser cookies to the downloader so it can access the book on your behalf.
+
+#### When do I need this?
+
+- You can open and read the book in your browser, but the downloader gives **403** errors.
+- You are accessing HathiTrust through a university or library login.
+- You are outside the US and some books are blocked in your region, but you have legitimate access through an institution.
+
+#### Step 1: Log in to HathiTrust in your browser
+
+Open [HathiTrust](https://www.hathitrust.org/) in your browser and log in through your institution. Verify that you can view the book you want to download.
+
+#### Step 2: Export your cookies
+
+You need to export your browser cookies for `hathitrust.org` into a text file. The easiest way to do this is with a browser extension:
+
+- **Firefox**: Install the [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/) extension. After installing, navigate to the HathiTrust page, click the extension icon, and select **"Export"** to save the cookies to a file (e.g. `cookies.txt`).
+- **Chrome**: Install the [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc) extension. Navigate to the HathiTrust page, click the extension icon, and export the cookies.
+
+> [!NOTE]
+> The exported file must be in **Netscape/Mozilla cookie jar format** (this is the default format for the extensions listed above). The file typically looks like a text file with tab-separated values — you do not need to edit it.
+
+#### Step 3: Use the `--cookies` flag
+
+Pass the path to your exported cookie file using the `--cookies` flag:
+
+```bash
+hathitrust-downloader mdp.39015073487137 1 10 --name my-book --cookies cookies.txt
+```
+
+That's it! The downloader will now use your browser session to authenticate with HathiTrust.
+
+> [!WARNING]
+> Cookie files contain sensitive session data. Do not share your `cookies.txt` file with others. Cookies typically expire after some time, so you may need to re-export them if your downloads start failing again.
+
 ### Client Certificate Authentication (Advanced)
 
 If your institution uses client SSL certificates to authenticate access to restricted HathiTrust volumes, you can specify them using the `--cert` and `--key` switches:
@@ -106,8 +144,14 @@ If your institution uses client SSL certificates to authenticate access to restr
 hathitrust-downloader mdp.39015073487137 1 10 --cert my-cert.pem --key my-key.pem
 ```
 
+You can also combine cookies with client certificates if needed:
+
+```bash
+hathitrust-downloader mdp.39015073487137 1 10 --cookies cookies.txt --cert my-cert.pem --key my-key.pem
+```
+
 > [!NOTE]
-> The certificate and key files should be in **PEM format**.
+> The certificate and key files should be in **PEM format**. Most users will only need `--cookies`. Client certificates are uncommon and typically only required by specific institutional setups. If you are unsure, start with just `--cookies`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Now you can use the tool by typing commands into the shell like this, and then p
 The help should give some instructions on how to use the tool:
 
 usage: hathitrust-downloader [-h] [--name NAME] [--user-agent USER_AGENT]
-                             [--max-retries MAX_RETRIES] [--cookies COOKIE_JAR]
+                             [--max-retries MAX_RETRIES] [--cookies COOKIES]
                              [--cert CERT_FILE] [--key KEY_FILE]
                              id start_page end_page
 
@@ -71,7 +71,7 @@ options:
                         The User-Agent string to use for requests.
   --max-retries MAX_RETRIES
                         The maximum number of retries for retriable errors (e.g., 403 Forbidden) before skipping a page. Default is 8.
-  --cookies COOKIE_JAR  Path to a Netscape-format cookie jar file for authenticated requests.
+  --cookies COOKIES     A raw cookie string (e.g. 'name=val; name2=val2') or the path to a Netscape-format cookie jar file.
   --cert CERT_FILE      Path to a client SSL certificate file (PEM format) for authentication.
   --key KEY_FILE        Path to a private key file (PEM format) corresponding to the client certificate.
 ```
@@ -101,40 +101,36 @@ hathitrust-downloader mdp.39015073487137 1 10 --name my-book
 
 ### Authentication
 
-Some books on HathiTrust are only available if you are logged in through a partner institution, or if you are connecting from a specific region (e.g. the United States). If you are getting **403 Forbidden** errors or the download keeps retrying without making progress, you may need to pass your browser cookies to the downloader so it can access the book on your behalf.
+> [!IMPORTANT]
+> **Nearly all downloads from HathiTrust now require authentication.** HathiTrust uses Cloudflare bot detection, which blocks unauthenticated programmatic clients with a `403 Forbidden` error. You must solve the Cloudflare challenge in your browser first and pass your active session cookies to the downloader.
 
-#### When do I need this?
+You can supply cookies to the downloader in two ways: passing a raw cookie string directly or providing a cookie jar file on disk.
 
-- You can open and read the book in your browser, but the downloader gives **403** errors.
-- You are accessing HathiTrust through a university or library login.
-- You are outside the US and some books are blocked in your region, but you have legitimate access through an institution.
+#### Option A: Use a Raw Cookie String (Easiest)
 
-#### Step 1: Log in to HathiTrust in your browser
+1. Log in to HathiTrust in your browser and open the book reader.
+2. Open the Developer Tools (F12 or right-click -> Inspect).
+3. Go to the **Network** tab, reload the page, and select any document request (e.g. the main page or page image request).
+4. Look under **Request Headers** for the `Cookie:` header, and copy its entire value.
+5. Pass this copied string directly to `--cookies`:
+   ```bash
+   hathitrust-downloader mdp.39015073487137 1 10 --cookies "cookie_name=cookie_val; another_cookie=val"
+   ```
 
-Open [HathiTrust](https://www.hathitrust.org/) in your browser and log in through your institution. Verify that you can view the book you want to download.
+#### Option B: Use a Cookie Jar File
 
-#### Step 2: Export your cookies
-
-You need to export your browser cookies for `hathitrust.org` into a text file. The easiest way to do this is with a browser extension:
-
-- **Firefox**: Install the [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/) extension. After installing, navigate to the HathiTrust page, click the extension icon, and select **"Export"** to save the cookies to a file (e.g. `cookies.txt`).
-- **Chrome**: Install the [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc) extension. Navigate to the HathiTrust page, click the extension icon, and export the cookies.
-
-> [!NOTE]
-> The exported file must be in **Netscape/Mozilla cookie jar format** (this is the default format for the extensions listed above). The file typically looks like a text file with tab-separated values — you do not need to edit it.
-
-#### Step 3: Use the `--cookies` flag
-
-Pass the path to your exported cookie file using the `--cookies` flag:
-
-```bash
-hathitrust-downloader mdp.39015073487137 1 10 --name my-book --cookies cookies.txt
-```
-
-That's it! The downloader will now use your browser session to authenticate with HathiTrust.
+1. Log in to HathiTrust in your browser.
+2. Install a browser extension to export cookies in Netscape format:
+   - **Firefox**: [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/)
+   - **Chrome**: [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
+3. Navigate to HathiTrust, click the extension icon, and export the cookies to a file (e.g., `cookies.txt`).
+4. Pass the path to your exported cookie file:
+   ```bash
+   hathitrust-downloader mdp.39015073487137 1 10 --cookies cookies.txt
+   ```
 
 > [!WARNING]
-> Cookie files contain sensitive session data. Do not share your `cookies.txt` file with others. Cookies typically expire after some time, so you may need to re-export them if your downloads start failing again.
+> Cookies contain sensitive session data. Do not share your cookies or cookie files. They will expire after some time, so you may need to grab a fresh session/file if downloads begin failing again with 403 errors.
 
 ### Client Certificate Authentication (Advanced)
 

--- a/hathitrustdownloader/cli.py
+++ b/hathitrustdownloader/cli.py
@@ -4,6 +4,7 @@ import requests
 import time
 import argparse
 from urllib.parse import urlparse, parse_qs
+import http.cookiejar as cookielib
 
 DEFAULT_USER_AGENT='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36'
 
@@ -30,10 +31,21 @@ def main():
     parser.add_argument('--name', dest='name', type=str, help="The start of the filename. Defaults to using the id. This can also be used to change the path.")
     parser.add_argument('--user-agent', dest='user_agent', type=str, help="The User-Agent string to use for requests.")
     parser.add_argument('--max-retries', dest='max_retries', type=int, default=8, help="The maximum number of retries for retriable errors (e.g., 403 Forbidden) before skipping a page. Default is 8.")
+    parser.add_argument('--cookies', dest='cookies', type=str, help="Path to a Netscape formatted cookies.txt file.")
     parser.add_argument('--cert', dest='cert', type=str, help="Path to a client certificate file (.pem).")
     parser.add_argument('--key', dest='key', type=str, help="Path to a private key file (.key).")
 
     args = parser.parse_args()
+
+    session = requests.Session()
+    if args.cookies:
+        try:
+            cookie_jar = cookielib.MozillaCookieJar(args.cookies)
+            cookie_jar.load()
+            session.cookies.update(cookie_jar)
+        except Exception as e:
+            print(f"Failed to load cookies from '{args.cookies}': {e}")
+            return
 
     cert = None
     if args.cert and args.key:
@@ -71,7 +83,7 @@ def main():
                 headers = {
                     'User-Agent': user_agent,
                 }
-                response = requests.get(url, stream=True, headers=headers, cert=cert)
+                response = session.get(url, stream=True, headers=headers, cert=cert)
 
                 if response.status_code == 403:
                     if retries < args.max_retries:

--- a/hathitrustdownloader/cli.py
+++ b/hathitrustdownloader/cli.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument('--name', dest='name', type=str, help="The start of the filename. Defaults to using the id. This can also be used to change the path.")
     parser.add_argument('--user-agent', dest='user_agent', type=str, help="The User-Agent string to use for requests.")
     parser.add_argument('--max-retries', dest='max_retries', type=int, default=8, help="The maximum number of retries for retriable errors (e.g., 403 Forbidden) before skipping a page. Default is 8.")
-    parser.add_argument('--cookies', dest='cookies', type=str, help="Path to a Netscape formatted cookies.txt file.")
+    parser.add_argument('--cookies', dest='cookies', type=str, help="A raw cookie string (e.g. 'name=val; name2=val2') or the path to a Netscape formatted cookies.txt file.")
     parser.add_argument('--cert', dest='cert', type=str, help="Path to a client certificate file (.pem).")
     parser.add_argument('--key', dest='key', type=str, help="Path to a private key file (.key).")
 
@@ -39,13 +39,26 @@ def main():
 
     session = requests.Session()
     if args.cookies:
-        try:
-            cookie_jar = cookielib.MozillaCookieJar(args.cookies)
-            cookie_jar.load()
-            session.cookies.update(cookie_jar)
-        except Exception as e:
-            print(f"Failed to load cookies from '{args.cookies}': {e}")
-            return
+        if os.path.isfile(args.cookies):
+            try:
+                cookie_jar = cookielib.MozillaCookieJar(args.cookies)
+                cookie_jar.load()
+                session.cookies.update(cookie_jar)
+            except Exception as e:
+                print(f"Failed to load cookies from file '{args.cookies}': {e}")
+                return
+        else:
+            try:
+                from http.cookies import SimpleCookie
+                cookie = SimpleCookie()
+                cookie.load(args.cookies)
+                cookies_dict = {key: morsel.value for key, morsel in cookie.items()}
+                if not cookies_dict:
+                    raise ValueError("No valid cookies could be parsed.")
+                session.cookies.update(cookies_dict)
+            except Exception as e:
+                print(f"Failed to parse cookies string: {e}")
+                return
 
     cert = None
     if args.cert and args.key:


### PR DESCRIPTION
This PR adds the --cookies authentication CLI option to the HathiTrust downloader and updates the README with documentation. This allows users to bypass Cloudflare bot challenges and geoblocks by exporting cookies from their browser session (resolving #31 and #41).